### PR TITLE
Some updates for disaster recovery use

### DIFF
--- a/zfsimpl.c
+++ b/zfsimpl.c
@@ -1178,8 +1178,8 @@ zio_read(const spa_t *spa, const blkptr_t *bp, void *buf)
 			break;
 	}
 	if (error != 0)
-		printf("ZFS: i/o error - all block copies unavailable\n");
-	return (error);
+		printf("ZFS: i/o error !!!- all block copies unavailable\n");
+	return (0); /* error); */
 }
 
 static int

--- a/zfsimpl.c
+++ b/zfsimpl.c
@@ -930,8 +930,13 @@ vdev_probe(vdev_phys_read_t *read, void *read_priv, spa_t **spap)
 	if (nvlist_find(nvlist,
 			ZPOOL_CONFIG_FEATURES_FOR_READ,
 			DATA_TYPE_NVLIST, 0, &features) == 0
-	    && nvlist_check_features_for_read(features) != 0)
-		return (EIO);
+	    && nvlist_check_features_for_read(features) != 0) {
+
+        //unsupported flags are maybe not too bad
+        if (opt_ignore_errors == 0) {
+			return (EIO);
+        }
+}
 
 	if (nvlist_find(nvlist,
 			ZPOOL_CONFIG_POOL_STATE,
@@ -1179,7 +1184,9 @@ zio_read(const spa_t *spa, const blkptr_t *bp, void *buf)
 	}
 	if (error != 0)
 		printf("ZFS: i/o error !!!- all block copies unavailable\n");
-	return (0); /* error); */
+        if (opt_ignore_errors > 1)
+            return 0;
+	return (error);
 }
 
 static int


### PR DESCRIPTION
I used your tool a couple years ago - it really saved me, but I had to make a few changes to a make it more lenient. Since it was an ubuntu zfs partition, the normal partition specification didn't work.

With these changes, you can also operate on a partition backed up to a file using `dd`

Also, due to disk errors, I had to tell it to skip certain parts, so I added functionality for skipping things.

After cleaning it up finally recently, I couldn't get it to compile. The changes for that are here: https://github.com/tschundler/zfs_read/commit/bb847d7ce15df494a9515793ed7410533a03be14
